### PR TITLE
Rollback to Java 1.8 so that it can be included in CodeGen CI Pipeline

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.10-zulu
+java=8.0.292-zulu

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
 group = "com.example"
 version = "0.0.1-SNAPSHOT"
-java.sourceCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
 	mavenCentral()
@@ -47,8 +47,8 @@ tasks.withType<com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask> {
 
 tasks.withType<JavaCompile> {
 	java {
-		targetCompatibility = JavaVersion.VERSION_11
-		sourceCompatibility = JavaVersion.VERSION_11
+		targetCompatibility = JavaVersion.VERSION_1_8
+		sourceCompatibility = JavaVersion.VERSION_1_8
 	}
 }
 

--- a/src/main/java/com/example/demo/datafetchers/ReviewsDataFetcher.java
+++ b/src/main/java/com/example/demo/datafetchers/ReviewsDataFetcher.java
@@ -11,9 +11,13 @@ import org.dataloader.DataLoader;
 import org.reactivestreams.Publisher;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -52,17 +56,17 @@ public class ReviewsDataFetcher {
 
         List<Review> reviews = reviewsService.reviewsForShow(review.getShowId());
 
-        return Objects.requireNonNullElseGet(reviews, List::of);
+        return Optional.ofNullable(reviews).orElse(Collections.emptyList());
     }
 
     @DgsMutation
     public List<Review> addReviews(@InputArgument(value = "reviews", collectionType = SubmittedReview.class) List<SubmittedReview> reviewsInput) {
         reviewsService.saveReviews(reviewsInput);
 
-        List<Integer> showIds = reviewsInput.stream().map(review -> review.getShowId()).collect(Collectors.toList());
+        List<Integer> showIds = reviewsInput.stream().map(SubmittedReview::getShowId).collect(Collectors.toList());
         Map<Integer, List<Review>> reviews = reviewsService.reviewsForShows(showIds);
 
-        return new ArrayList(reviews.values());
+        return reviews.values().stream().flatMap(List::stream).collect(Collectors.toList());
     }
 
     @DgsSubscription

--- a/src/main/java/com/example/demo/services/DefaultReviewsService.java
+++ b/src/main/java/com/example/demo/services/DefaultReviewsService.java
@@ -79,12 +79,15 @@ public class DefaultReviewsService implements ReviewsService {
     public Map<Integer, List<Review>> reviewsForShows(List<Integer> showIds) {
         logger.info("Loading reviews for shows {}", showIds.stream().map(String::valueOf).collect(Collectors.joining(", ")));
 
-        return reviews.entrySet().stream().filter(entry -> showIds.contains(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return reviews
+                .entrySet()
+                .stream()
+                .filter(entry -> showIds.contains(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public void saveReview(SubmittedReview reviewInput) {
-        var reviewsForShow = reviews.computeIfAbsent(reviewInput.getShowId(), (key) -> new ArrayList<>());
-        var review = Review.newBuilder()
+        List<Review> reviewsForShow = reviews.computeIfAbsent(reviewInput.getShowId(), (key) -> new ArrayList<>());
+        Review review = Review.newBuilder()
                 .username(reviewInput.getUsername())
                 .starScore(reviewInput.getStarScore())
                 .submittedDate(OffsetDateTime.now()).build();
@@ -97,8 +100,8 @@ public class DefaultReviewsService implements ReviewsService {
 
     public void saveReviews(List<SubmittedReview> reviewsInput) {
         reviewsInput.forEach(reviewInput -> {
-            var reviewsForShow = reviews.computeIfAbsent(reviewInput.getShowId(), (key) -> new ArrayList<>());
-            var review = Review.newBuilder()
+            List<Review> reviewsForShow = reviews.computeIfAbsent(reviewInput.getShowId(), (key) -> new ArrayList<>());
+            Review review = Review.newBuilder()
                     .username(reviewInput.getUsername())
                     .starScore(reviewInput.getStarScore())
                     .submittedDate(OffsetDateTime.now()).build();

--- a/src/main/java/com/example/demo/services/ShowsServiceImpl.java
+++ b/src/main/java/com/example/demo/services/ShowsServiceImpl.java
@@ -3,13 +3,14 @@ package com.example.demo.services;
 import com.example.demo.generated.types.Show;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
 public class ShowsServiceImpl implements ShowsService {
     @Override
     public List<Show> shows() {
-        return List.of(
+        return Arrays.asList(
                 Show.newBuilder().id(1).title("Stranger Things").releaseYear(2016).build(),
                 Show.newBuilder().id(2).title("Ozark").releaseYear(2017).build(),
                 Show.newBuilder().id(3).title("The Crown").releaseYear(2016).build(),

--- a/src/test/java/com/example/demo/ReviewSubscriptionTest.java
+++ b/src/test/java/com/example/demo/ReviewSubscriptionTest.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -48,7 +47,7 @@ public class ReviewSubscriptionTest {
         Publisher<ExecutionResult> reviewPublisher = executionResult.getData();
         List<Review> reviews = new CopyOnWriteArrayList<>();
 
-        reviewPublisher.subscribe(new Subscriber<>() {
+        reviewPublisher.subscribe(new Subscriber<ExecutionResult>() {
             @Override
             public void onSubscribe(Subscription s) {
                 s.request(2);

--- a/src/test/java/com/example/demo/ShowsDatafetcherTest.java
+++ b/src/test/java/com/example/demo/ShowsDatafetcherTest.java
@@ -15,6 +15,7 @@ import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest;
 import graphql.ExecutionResult;
+import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -23,6 +24,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -44,10 +47,11 @@ class ShowsDatafetcherTest {
 
     @BeforeEach
     public void before() {
-        Mockito.when(showsService.shows()).thenAnswer(invocation -> List.of(Show.newBuilder().id(1).title("mock title").releaseYear(2020).build()));
-        Mockito.when(reviewsService.reviewsForShows(List.of(1)))
+        Mockito.when(showsService.shows())
+                .thenAnswer(invocation -> Collections.singletonList(Show.newBuilder().id(1).title("mock title").releaseYear(2020).build()));
+        Mockito.when(reviewsService.reviewsForShows(Collections.singletonList(1)))
                 .thenAnswer(invocation ->
-                        Map.of(1, List.of(
+                        Maps.newHashMap(1, Arrays.asList(
                                 Review.newBuilder().username("DGS User").starScore(5).submittedDate(OffsetDateTime.now()).build(),
                                 Review.newBuilder().username("DGS User 2").starScore(3).submittedDate(OffsetDateTime.now()).build())
                         ));
@@ -119,7 +123,7 @@ class ShowsDatafetcherTest {
 
     @Test
     void addReviewsMutation() {
-        List<SubmittedReview> reviews = List.of(
+        List<SubmittedReview> reviews = Collections.singletonList(
                 SubmittedReview.newBuilder().showId(1).username("testuser1").starScore(5).build());
         GraphQLQueryRequest graphQLQueryRequest = new GraphQLQueryRequest(
                 AddReviewsGraphQLQuery.newRequest()
@@ -130,6 +134,6 @@ class ShowsDatafetcherTest {
         ExecutionResult executionResult = dgsQueryExecutor.execute(graphQLQueryRequest.serialize());
         assertThat(executionResult.getErrors()).isEmpty();
 
-        verify(reviewsService).reviewsForShows(List.of(1));
+        verify(reviewsService).reviewsForShows(Collections.singletonList(1));
     }
 }


### PR DESCRIPTION
We intend to use this example project as part of the CI Pipeline for the [DGS Codegen] project. That project builds with JDK 1.8.
To facilitate such CI Pipeline we need to move this example project to JDK 1.8.

[DGS Codegen]: https://github.com/Netflix/dgs-codegen