### PR TITLE
Remove unnecessary spring-boot-dependency plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,8 @@
 
 plugins {
     id("java")
-    id("org.springframework.boot") version "2.4.5"
-    id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("com.netflix.dgs.codegen") version "4.6.4"
+    id("org.springframework.boot") version "2.4.5"
 }
 
 group = "com.example"


### PR DESCRIPTION
We are including the graphql-dgs-platform-dependencies BOM and through
it manage dependencies.