### PR TITLE
Migrated to Datafaker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
     implementation("com.netflix.graphql.dgs:graphql-dgs-extended-scalars")
     implementation("com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.github.javafaker:javafaker:1.+")
+    implementation("net.datafaker:datafaker:1.+")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework.boot:spring-boot-starter-security")
 

--- a/src/main/java/com/example/demo/services/DefaultReviewsService.java
+++ b/src/main/java/com/example/demo/services/DefaultReviewsService.java
@@ -2,7 +2,7 @@ package com.example.demo.services;
 
 import com.example.demo.generated.types.Review;
 import com.example.demo.generated.types.SubmittedReview;
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Javafaker is currently unmaintained and has several CVEs, while Datafaker is an active port of Javafaker, with the same API, but without the security issues (and a whole lot of improvements).

(Disclaimer: I'm one of the maintainers of Datafaker)