### PR TITLE
Demo the micrometer integration.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.0.0"
+    id("org.springframework.boot") version "2.7.7"
     id("io.spring.dependency-management") version "1.1.0"
     id("com.netflix.dgs.codegen") version "5.6.0"
 }
@@ -64,6 +64,26 @@ dependencies {
     implementation("net.datafaker:datafaker:1.+")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // ----
+    // Enabling Metrics!
+    //
+    // First, we need to enable Spring Boot's actuators.
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    // Second, enable DGS micrometer metrics integration.
+    implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer")
+    // Third, choose a Micrometer Registry implementation, in this case we will just use the LoggingMeterRegistry to
+    // demo. We will have to create a LoggingMeterRegistry bean, refer to the MicrometerConfig.java file.
+    // If you want to see the metrics appear in your logs you will have to enable the logger for the
+    // `io.micrometer.core.instrument.logging` package. You can do this by adding the following lines to your
+    // `application.yml` file...
+    // ```
+    // logging:
+    //  level:
+    //      io.micrometer.core.instrument.logging: INFO
+    // ```
+    implementation("io.micrometer:micrometer-core")
+    // ----
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.netflix.graphql.dgs:graphql-dgs-client")

--- a/src/main/java/com/example/demo/config/MicrometerConfig.java
+++ b/src/main/java/com/example/demo/config/MicrometerConfig.java
@@ -1,0 +1,20 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Bean;
+
+import org.springframework.context.annotation.Configuration;
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+
+
+@Configuration
+public class MicrometerConfig {
+
+  @Bean
+  public MeterRegistry loggingMeterRegistry() {
+        return new LoggingMeterRegistry();
+  }
+}
+

--- a/src/main/java/com/example/demo/services/DefaultReviewsService.java
+++ b/src/main/java/com/example/demo/services/DefaultReviewsService.java
@@ -11,7 +11,7 @@ import reactor.core.publisher.ConnectableFlux;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
-import jakarta.annotation.PostConstruct;
+import javax.annotation.PostConstruct;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,12 @@ spring:
   application:
     name: dgs-example-java
 
+logging:
+  level:
+    io.micrometer.core.instrument.logging: INFO
+
+debug: true
+
 ---
 spring:
   config:


### PR DESCRIPTION
This PR describes the steps you need to follow to integrate with the DGS Metrics.
To summarize the steps you need to...

1. We need to enable Spring Boot's actuators.
   `implementation("org.springframework.boot:spring-boot-starter-actuator")`
2. Enable DGS micrometer metrics integration.
   `implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer")`
3. Choose a Micrometer Registry implementation, in this case we will just use the `LoggingMeterRegistry` to demo. We will have to create a `LoggingMeterRegistry` bean, refer to the `MicrometerConfig.java` file.
   If you want to see the metrics appear in your logs you will have to enable the logger for the `io.micrometer.core.instrument.logging` package. You can do this by adding the following lines to your `application.yml` file...
   ```
   logging:
     level:
       io.micrometer.core.instrument.logging: INFO
   ```

For now I'm reverting to SpringBoot 2.7 since that is the version the latest release supports.