### PR TITLE
Rename ShowsDataFetcher class to its own java file name

### DIFF
--- a/src/main/java/com/example/demo/datafetchers/ShowsDataFetcher.java
+++ b/src/main/java/com/example/demo/datafetchers/ShowsDataFetcher.java
@@ -10,15 +10,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @DgsComponent
-public class ShowsDatafetcher {
+public class ShowsDataFetcher {
     private final ShowsService showsService;
 
-    public ShowsDatafetcher(ShowsService showsService) {
+    public ShowsDataFetcher(ShowsService showsService) {
         this.showsService = showsService;
     }
 
     /**
-     * This datafetcher resolves the shows field on Query.
+     * This dataFetcher resolves the shows field on Query.
      * It uses an @InputArgument to get the titleFilter from the Query if one is defined.
      */
     @DgsQuery

--- a/src/test/java/com/example/demo/ShowsDataFetcherTest.java
+++ b/src/test/java/com/example/demo/ShowsDataFetcherTest.java
@@ -1,7 +1,7 @@
 package com.example.demo;
 
 import com.example.demo.datafetchers.ReviewsDataFetcher;
-import com.example.demo.datafetchers.ShowsDatafetcher;
+import com.example.demo.datafetchers.ShowsDataFetcher;
 import com.example.demo.dataloaders.ReviewsDataLoader;
 import com.example.demo.dataloaders.ReviewsDataLoaderWithContext;
 import com.example.demo.generated.client.*;
@@ -28,14 +28,13 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, ReviewsDataLoaderWithContext.class, ShowsDatafetcher.class, ReviewsDataFetcher.class, ReviewsDataLoader.class, DateTimeScalar.class})
-class ShowsDatafetcherTest {
+@SpringBootTest(classes = {DgsAutoConfiguration.class, ReviewsDataLoaderWithContext.class, ShowsDataFetcher.class, ReviewsDataFetcher.class, ReviewsDataLoader.class, DateTimeScalar.class})
+class ShowsDataFetcherTest {
 
     @Autowired
     DgsQueryExecutor dgsQueryExecutor;


### PR DESCRIPTION
I guess the intention was `ShowsDataFetcher` as the class name